### PR TITLE
针对设备列表增加部分列

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -91,9 +91,15 @@
                     <i v-if="scope.row.owner==user.email" class="fas fa-lock color-yellow"></i>
                     <i v-else class="fas fa-user" :title="scope.row.owner"></i>
                 </template>
-                <span v-text="scope.row.prop_name"></span>
+                <atx-edit-inline :readonly="!user.admin" :value="scope.row.prop_name"
+                    @change="updatePropertyName(scope.row.udid, $event)">
+                </atx-edit-inline>
             </template>
         </el-table-column>
+
+        <el-table-column prop="prop_model" sortable label="型号"></el-table-column>
+        <el-table-column prop="prop_brand" sortable label="品牌"></el-table-column>
+
         <el-table-column :sort-method="tableSortBy('prop_propertyId')" sortable label="资产编号">
             <template slot-scope="scope">
                 <!-- <el-input size="mini"></el-input> -->
@@ -117,6 +123,17 @@
                 </template>
             </template>
         </el-table-column>
+
+       <el-table-column :sort-method="tableSortBy('department')" sortable label="所属部门">
+            <template slot-scope="scope">
+                <!-- <el-input size="mini"></el-input> -->
+                <atx-edit-inline :readonly="!user.admin" :value="scope.row.department"
+                    @change="updateDeviceDepartment(scope.row.udid, $event)">
+                </atx-edit-inline>
+                <!-- <span v-text="prop_propertyId"></span> <i class="fas fa-edit cursor-pointer"></i> -->
+            </template>
+        </el-table-column>
+
         <!-- <el-table-column prop="prop_brand" label="品牌"></el-table-column> -->
         <el-table-column prop="prop_version" sortable :sort-method="semverCompare" label="Version"></el-table-column>
         <el-table-column sortable :sort-method="tableSortBy('usingDuration')" label="使用时长">
@@ -291,6 +308,38 @@
                             contentType: "application/json",
                             data: JSON.stringify({
                                 "propertyId": text,
+                            })
+                        }).fail(ret => {
+                            if (ret.status == 400) {
+                                this.$message.error(ret.responseJSON.description)
+                            } else {
+                                this.$message.error(ret.responseText)
+                            }
+                        })
+                    },
+                    updatePropertyName(udid, text) { // admin required
+                        $.ajax({
+                            url: "/api/v1/devices/" + udid + "/properties",
+                            method: "put",
+                            contentType: "application/json",
+                            data: JSON.stringify({
+                                "name": text,
+                            })
+                        }).fail(ret => {
+                            if (ret.status == 400) {
+                                this.$message.error(ret.responseJSON.description)
+                            } else {
+                                this.$message.error(ret.responseText)
+                            }
+                        })
+                    },
+                    updateDeviceDepartment(udid, text) { // admin required
+                        $.ajax({
+                            url: "/api/v1/devices/" + udid,
+                            method: "put",
+                            contentType: "application/json",
+                            data: JSON.stringify({
+                                "department": text,
                             })
                         }).fail(ret => {
                             if (ret.status == 400) {

--- a/web/views/device.py
+++ b/web/views/device.py
@@ -128,6 +128,17 @@ class APIDeviceHandler(CorsMixin, BaseRequestHandler):
             "device": data,
         })
 
+    @catch_error_wraps(rdb.errors.ReqlNonExistenceError)
+    async def put(self, udid):
+        if not self.current_user.admin:
+            raise RuntimeError("Update requires admin")
+
+        props = self.get_payload()
+        await db.table("devices").get(udid).update({
+            "department": props['department'],
+        })
+        self.write_json({"success": True, "description": "updated"})
+
 
 class APIDevicePropertiesHandler(CorsMixin, BaseRequestHandler):
     @catch_error_wraps(rdb.errors.ReqlNonExistenceError)


### PR DESCRIPTION
1. 设备名字支持可编辑（因为provider的对应关系不能保证实施更新）
2. 设备列表栏，额外添加型号，品牌， 所属部门（能知道手机在哪个设备上插着， 后面可以做成下拉列表，并后台管理中可维护）