### PR TITLE
新增location的管理页面

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -10,36 +10,113 @@
 
 {% block content %}
 <div class="container">
-    <div style="margin: 10px 0px">
-        接口 <a href="/api/v1/admins">/api/v1/admins</a>
-    </div>
-    <div>
-        <form class="form-inline" @submit.prevent="addAdmin">
-            <div class="form-group">
-                <label style="margin-right: 1em">用户邮箱</label>
-                <input style="margin-right: 1em" v-model="formEmail" placeholder="email ..." class="form-control">
-                <button class="btn btn-success">新增管理员</button>
-            </div>
-        </form>
-        <br>
-        <table class="table">
-            <thead>
-                <tr>
-                    <th>邮箱</th>
-                    <th>用户名</th>
-                    <th>上次登录时间</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr v-for="u in users">
-                    <td v-text="u.email"></td>
-                    <td v-text="u.username"></td>
-                    <td v-text="u.lastLoggedInAt"></td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
+    <el-tabs v-model="tabActiveName" @tab-click="handleGetLocation">
+        <el-tab-pane label="管理员管理" name="admin">
+                <div style="margin: 10px 0px">
+                    接口 <a href="/api/v1/admins">/api/v1/admins</a>
+                </div>
+                <div>
+                </div>
+                <div>
+                    <form class="form-inline" @submit.prevent="addAdmin">
+                        <div class="form-group">
+                            <label style="margin-right: 1em">用户邮箱</label>
+                            <input style="margin-right: 1em" v-model="formEmail" placeholder="email ..." class="form-control">
+                            <button class="btn btn-success">新增管理员</button>
+                        </div>
+                    </form>
+                    <br>
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>邮箱</th>
+                                <th>用户名</th>
+                                <th>上次登录时间</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="u in users">
+                                <td v-text="u.email"></td>
+                                <td v-text="u.username"></td>
+                                <td v-text="u.lastLoggedInAt"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+        </el-tab-pane>
+        <el-tab-pane label="设备-所在地管理" name="dept">
+                 <el-button
+                        size="mini"
+                        type="primary"
+                        @click="openNewLocationDialog"
+                >新建
+                </el-button>
+
+                <el-table
+                    :data="eqtLocationDatas"
+                    stripe
+                    element-loading-text="大爷稍等片刻哟~~~"
+                    border
+                    style="width: 100%; margin-top: 20px"
+                    size="small"
+                    :header-cell-style="tableHeaderColor"
+                >
+                    <el-table-column
+                            prop="location"
+                            label="设备所在地 or 所在机器">
+                    </el-table-column>
+                    <el-table-column
+                            prop="providerIP"
+                            label="机器的IP（如果是USB链接的话）">
+                    </el-table-column>
+                    <el-table-column
+                            label="操作">
+                        <template slot-scope="scope">
+                            <el-button
+                                    size="mini"
+                                    type="primary"
+                                    icon="el-icon-edit"
+                                    circle
+                                    @click="openEditLocationDialog(scope.$index, scope.row)"
+                            >
+                            </el-button
+                            >
+                            <el-button
+                                    size="mini"
+                                    type="danger"
+                                    icon="el-icon-delete"
+                                    circle
+                                    @click="handleDeleteLocation(scope.$index, scope.row)"
+                            >
+                            </el-button
+                            >
+                        </template>
+                    </el-table-column>
+                </el-table>
+
+        </el-tab-pane>
+    </el-tabs>
+
+
+
+
 </div>
+<el-dialog :title="locationOperTitle" :visible.sync="dialogTableVisible">
+  <el-form :model="form">
+    <el-form-item label="所在地 or 所在机器名称" >
+      <el-input v-model="form.location"></el-input>
+    </el-form-item>
+    <el-form-item label="所在机器IP（USB插在哪个机器上）">
+        <el-input v-model="form.providerIP"></el-input>
+    </el-form-item>
+  </el-form>
+  <div slot="footer" class="dialog-footer">
+    <el-button @click="dialogTableVisible = false">取 消</el-button>
+    <el-button v-if="locationOperAction === 'new'" type="primary" @click="handleNewLocation">确 定</el-button>
+      <el-button v-else="locationOperAction === 'edit'" type="primary" @click="handleEditLocation">保 存</el-button>
+  </div>
+</el-dialog>
+
 {% end %}
 
 {% block script %}
@@ -49,9 +126,20 @@
             new Vue({
                 el: "#app",
                 data: Object.assign({
+                    locationOperTitle: '',
+                    locationOperAction : '',
+                    dialogTableVisible: false,
+                    tabActiveName: "admin",
                     formEmail: "",
                     users: [],
                     token: "",
+                    form:{
+                        "location": "",
+                        "providerIP":"",
+                        "id":""
+                    },
+                    eqtLocationDatas:[
+                    ]
                 }, ret),
                 methods: {
                     addAdmin() {
@@ -65,7 +153,86 @@
                             console.log(ret)
                             this.$message("添加成功")
                         })
-                    }
+                    },
+                    tableHeaderColor ({row, column, rowIndex, columnIndex}) {
+                        if (rowIndex === 0) {
+                            return 'background-color: #D2E9FF;'
+                        }
+                    },
+                    openNewLocationDialog(){
+                        let that = this
+                        that.locationOperAction = 'new'
+                        that.locationOperTitle = '新建'
+                        that.dialogTableVisible = true
+                    },
+                    openEditLocationDialog(index, row){
+                        let that = this
+                        that.locationOperAction = 'edit'
+                        that.locationOperTitle = '编辑'
+                        that.form.location = row.location
+                        that.form.providerIP = row.providerIP
+                        that.form.id = row.id
+                        that.dialogTableVisible = true
+                    },
+                    handleNewLocation(){
+                        let that = this
+                        $.ajax({
+                            url: "/api/v1/location",
+                            method: "post",
+                            data: JSON.stringify({
+                                location: that.form.location,
+                                providerIP: that.form.providerIP
+                            })
+                        }).then(ret => {
+                            console.log(ret)
+                            this.$message("添加成功")
+                        })
+                        that.dialogTableVisible = false
+                        that.handleGetLocation({'name':'dept'})
+                    },
+                    handleGetLocation(value){
+                        let that = this
+                        if(value.name === 'dept'){
+                            $.ajax({
+                                url: "/api/v1/location",
+                                method: "get"
+                            }).then(ret => {
+                                that.eqtLocationDatas = ret.location
+                                console.log(ret)
+                            })
+                        }
+                    },
+                    handleEditLocation(){
+                        let that = this
+                        $.ajax({
+                            url: "/api/v1/location/" + that.form.id,
+                            method: "put",
+                            data: JSON.stringify({
+                                    location: that.form.location,
+                                    providerIP: that.form.providerIP
+                            })
+                        }).then(ret => {
+                            console.log(ret)
+                            this.$message("编辑成功")
+                        })
+                        that.dialogTableVisible = false
+                        that.handleGetLocation({'name':'dept'})
+
+                    },
+                    handleDeleteLocation(index, row){
+                        let that = this
+                        $.ajax({
+                        url: "/api/v1/location/" + row.id,
+                        method: "delete",
+                        }).then(ret => {
+                            console.log(ret)
+                            this.$message("删除成功")
+                        })
+                        that.handleGetLocation({'name':'dept'})
+
+
+                    },
+
                 }
             })
         })

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -107,13 +107,14 @@
       <el-input v-model="form.location"></el-input>
     </el-form-item>
     <el-form-item label="所在机器IP（USB插在哪个机器上）">
-        <el-input v-model="form.providerIP"></el-input>
+        <el-input v-if="locationOperAction === 'new'" v-model="form.providerIP"></el-input>
+        <el-input v-else :disabled="true" v-model="form.providerIP"></el-input>
     </el-form-item>
   </el-form>
   <div slot="footer" class="dialog-footer">
     <el-button @click="dialogTableVisible = false">取 消</el-button>
     <el-button v-if="locationOperAction === 'new'" type="primary" @click="handleNewLocation">确 定</el-button>
-      <el-button v-else="locationOperAction === 'edit'" type="primary" @click="handleEditLocation">保 存</el-button>
+    <el-button v-else="locationOperAction === 'edit'" type="primary" @click="handleEditLocation">保 存</el-button>
   </div>
 </el-dialog>
 
@@ -186,9 +187,10 @@
                         }).then(ret => {
                             console.log(ret)
                             this.$message("添加成功")
+                            that.dialogTableVisible = false
+                            that.handleGetLocation({'name':'dept'})
                         })
-                        that.dialogTableVisible = false
-                        that.handleGetLocation({'name':'dept'})
+
                     },
                     handleGetLocation(value){
                         let that = this
@@ -205,7 +207,7 @@
                     handleEditLocation(){
                         let that = this
                         $.ajax({
-                            url: "/api/v1/location/" + that.form.id,
+                            url: "/api/v1/location/" + that.form.providerIP,
                             method: "put",
                             data: JSON.stringify({
                                     location: that.form.location,
@@ -222,15 +224,13 @@
                     handleDeleteLocation(index, row){
                         let that = this
                         $.ajax({
-                        url: "/api/v1/location/" + row.id,
+                        url: "/api/v1/location/" + row.providerIP,
                         method: "delete",
                         }).then(ret => {
                             console.log(ret)
                             this.$message("删除成功")
                         })
                         that.handleGetLocation({'name':'dept'})
-
-
                     },
 
                 }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -216,9 +216,10 @@
                         }).then(ret => {
                             console.log(ret)
                             this.$message("编辑成功")
+                            that.dialogTableVisible = false
+                            that.handleGetLocation({'name':'dept'})
                         })
-                        that.dialogTableVisible = false
-                        that.handleGetLocation({'name':'dept'})
+
 
                     },
                     handleDeleteLocation(index, row){
@@ -229,8 +230,9 @@
                         }).then(ret => {
                             console.log(ret)
                             this.$message("删除成功")
+                            that.handleGetLocation({'name':'dept'})
                         })
-                        that.handleGetLocation({'name':'dept'})
+
                     },
 
                 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/vue@2.5.21/dist/vue.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/moment@2.23.0/moment.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/element-ui/2.4.11/index.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/element-ui/2.8.2/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/js/bootstrap.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/js-base64@2.5.1/base64.min.js"></script>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,9 +12,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css">
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.10/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.21/dist/vue.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/moment@2.23.0/moment.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/element-ui/2.8.2/index.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/element-ui/2.4.11/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/js/bootstrap.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/js-base64@2.5.1/base64.min.js"></script>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css">
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.21/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.10/dist/vue.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/moment@2.23.0/moment.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/element-ui/2.8.2/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/js/bootstrap.min.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -132,17 +132,9 @@ class="container-fluid"
         </el-table-column>
 
        <el-table-column :sort-method="tableSortBy('location')" sortable label="所属部门(机器)" >
-            <template slot-scope="scope">
-                <el-select v-model="scope.row.providerIP" placeholder="请选择" size="mini" style="width:100px" @change="updateDeviceLocation(scope.row)">
-                    <el-option
-                        v-for="item in locationOptions"
-                        :key="item.providerIP"
-                        :label="item.location"
-                        :value="item.providerIP">
-                    </el-option>
-                </el-select>
-                <!-- <span v-text="prop_propertyId"></span> <i class="fas fa-edit cursor-pointer"></i> -->
-            </template>
+           <template slot-scope="scope">
+                <span v-text="scope.row.locationProperties.location || scope.row.locationProperties.providerIP"></span>
+           </template>
         </el-table-column>
 
         <!-- <el-table-column prop="prop_brand" label="品牌"></el-table-column> -->
@@ -191,6 +183,7 @@ class="container-fluid"
                 }, { "devices": ret.devices }),
                 computed: {
                     tableData() {
+                        let that = this
                         let devices = this.orderedDevices.map(v => {
                             for (const key in v.properties) {
                                 if (v.properties.hasOwnProperty(key)) {
@@ -201,9 +194,21 @@ class="container-fluid"
                             v['display_size'] = display.width + "x" + display.height;
                             return v;
                         })
+
                         const fp = this.filters.platform
                         if (Object.values(fp).some(b => b)) {
                             devices = devices.filter(v => fp[v.platform])
+                        }
+
+                        // 将手机中的location字段，和实际维护的location表做匹配并转换
+
+                        for(let i=0; i < devices.length; i++){
+                            for(let j=0; j < that.locationOptions.length; j++){
+                                if(devices[i]['locationProperties']['providerIP'] === that.locationOptions[j]['providerIP']){
+                                    devices[i]['locationProperties']['location'] = that.locationOptions[j]['location']
+                                }
+
+                            }
                         }
                         return devices;
                     },
@@ -336,39 +341,6 @@ class="container-fluid"
                             contentType: "application/json",
                             data: JSON.stringify({
                                 "name": text,
-                            })
-                        }).fail(ret => {
-                            if (ret.status == 400) {
-                                this.$message.error(ret.responseJSON.description)
-                            } else {
-                                this.$message.error(ret.responseText)
-                            }
-                        })
-                    },
-                    updateDeviceLocation(data){ // admin required
-                        let that = this
-
-                        let udid = data.udid
-                        let locationProviderIP = data.providerIP
-
-                        let postLoaction = ''
-                        let postProviderIP = ''
-                        for(let i=0; i<that.locationOptions.length; i++){
-                            if(that.locationOptions[i]['providerIP'] === locationProviderIP){
-                                postLoaction = that.locationOptions[i]['location']
-                                postProviderIP = that.locationOptions[i]['providerIP']
-                            }
-                            else{
-                                // 不会出现这种情况
-                            }
-                        }
-                        $.ajax({
-                            url: "/api/v1/devices/" + udid,
-                            method: "put",
-                            contentType: "application/json",
-                            data: JSON.stringify({
-                                "location": postLoaction,
-                                "providerIP": postProviderIP,
                             })
                         }).fail(ret => {
                             if (ret.status == 400) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -64,7 +64,7 @@ class="container-fluid"
                     <el-button size="mini" disabled>设备离线</el-button>
                 </template>
                 <template v-else-if='"colding" == scope.row.status'>
-                    <el-button disabled :loading="true" size="mini" type="primary">释放中</span>
+                    <el-button disabled :loading="true" size="mini" type="primary">释放中</el-button>
                 </template>
                 <template v-else-if='"busy" == scope.row.status'>
                     <el-button :title="scope.row.userId" style="cursor: not-allowed; background: #f3d19e" size="mini"
@@ -131,12 +131,16 @@ class="container-fluid"
             </template>
         </el-table-column>
 
-       <el-table-column :sort-method="tableSortBy('department')" sortable label="所属部门">
+       <el-table-column :sort-method="tableSortBy('location')" sortable label="所属部门(机器)" >
             <template slot-scope="scope">
-                <!-- <el-input size="mini"></el-input> -->
-                <atx-edit-inline :readonly="!user.admin" :value="scope.row.department"
-                    @change="updateDeviceDepartment(scope.row.udid, $event)">
-                </atx-edit-inline>
+                <el-select v-model="scope.row.providerIP" placeholder="请选择" size="mini" style="width:100px" @change="updateDeviceLocation(scope.row)">
+                    <el-option
+                        v-for="item in locationOptions"
+                        :key="item.providerIP"
+                        :label="item.location"
+                        :value="item.providerIP">
+                    </el-option>
+                </el-select>
                 <!-- <span v-text="prop_propertyId"></span> <i class="fas fa-edit cursor-pointer"></i> -->
             </template>
         </el-table-column>
@@ -165,6 +169,7 @@ class="container-fluid"
             new Vue({
                 el: "#app",
                 data: Object.assign({
+                    locationOptions: [],
                     websocketDisconnected: false,
                     user: {
                         name: currentUserName,
@@ -340,13 +345,30 @@ class="container-fluid"
                             }
                         })
                     },
-                    updateDeviceDepartment(udid, text) { // admin required
+                    updateDeviceLocation(data){ // admin required
+                        let that = this
+
+                        let udid = data.udid
+                        let locationProviderIP = data.providerIP
+
+                        let postLoaction = ''
+                        let postProviderIP = ''
+                        for(let i=0; i<that.locationOptions.length; i++){
+                            if(that.locationOptions[i]['providerIP'] === locationProviderIP){
+                                postLoaction = that.locationOptions[i]['location']
+                                postProviderIP = that.locationOptions[i]['providerIP']
+                            }
+                            else{
+                                // 不会出现这种情况
+                            }
+                        }
                         $.ajax({
                             url: "/api/v1/devices/" + udid,
                             method: "put",
                             contentType: "application/json",
                             data: JSON.stringify({
-                                "department": text,
+                                "location": postLoaction,
+                                "providerIP": postProviderIP,
                             })
                         }).fail(ret => {
                             if (ret.status == 400) {
@@ -422,6 +444,17 @@ class="container-fluid"
                                 event.preventDefault()
                         }
                         console.log(device.udid)
+                    },
+                    getLocationOptions(){
+                        let that = this
+                        $.ajax({
+                            url: "/api/v1/location",
+                            method: "get"
+                        }).then(ret => {
+                            that.locationOptions = ret.location
+                            console.log(ret)
+                            {#this.$message("获取成功")#}
+                        })
                     }
                 },
                 components: {
@@ -470,6 +503,8 @@ class="container-fluid"
                     let wsURL = scheme + "://" + location.host + "/websocket/devicechanges";
                     let ws = new WebSocket(wsURL);
                     let refreshKey = null;
+                    this.getLocationOptions()
+
                     ws.onopen = (evt) => {
                         console.log("Websocket Connected")
                         refreshKey = setInterval(() => {

--- a/web/database.py
+++ b/web/database.py
@@ -28,6 +28,9 @@ class DB(object):
         "groups": {
             "name": "groups",
         },
+        "location": {
+            "name": "location"
+        }
     }
 
     def __init__(self, db='demo', **kwargs):

--- a/web/database.py
+++ b/web/database.py
@@ -29,7 +29,8 @@ class DB(object):
             "name": "groups",
         },
         "location": {
-            "name": "location"
+            "name": "location",
+            "primary_key": "providerIP",
         }
     }
 
@@ -214,13 +215,18 @@ class TableHelper(object):
                 results.append(await cursor.next())
             return results
 
-    async def save(self, data: dict, id=None) -> dict:
+    async def save(self, data: dict, id=None, excludeItems=None) -> dict:
         """Update when exists or insert it
 
         Returns:
             dict which will contains "id"
         """
         data = data.copy()
+
+        if excludeItems:
+            for item in excludeItems:
+                data.pop(item)
+
         if id:
             data[self.primary_key] = id
 
@@ -234,7 +240,6 @@ class TableHelper(object):
 
         # add some data
         data['createdAt'] = time_now()
-
         ret = await self.insert(data)
         assert ret['errors'] == 0
 

--- a/web/urls.py
+++ b/web/urls.py
@@ -16,7 +16,7 @@ from .views.provider import ProviderHeartbeatWSHandler
 from .views.upload import UploadItemHandler, UploadListHandler
 from .views.user import (
     AdminListHandler, APIAdminListHandler, APIUserHandler,
-    APIUserSettingsHandler, UserHandler)
+    APIUserSettingsHandler, UserHandler, APILocationListHandler)
 
 urlpatterns = [
     (r"/", MainHandler),
@@ -47,6 +47,8 @@ urlpatterns = [
     (r"/api/v1/user/devices/([^/]+)/active", APIUserDeviceActiveHandler), # GET
     (r"/api/v1/user/settings", APIUserSettingsHandler), # GET, PUT
     (r"/api/v1/admins", APIAdminListHandler), # GET, POST
+    (r"/api/v1/location/([^/]+)", APILocationListHandler),  # GET, POST, PUT, DELETE
+    (r"/api/v1/location", APILocationListHandler),  # GET, POST, PUT, DELETE
     ## Group API
     # (r"/api/v1/user/groups/([^/]+)", APIUserGroupHandler), # GET, POST, DELETE  TODO(ssx)
     (r"/api/v1/user/groups", APIUserGroupListHandler), # GET, POST

--- a/web/views/device.py
+++ b/web/views/device.py
@@ -128,17 +128,6 @@ class APIDeviceHandler(CorsMixin, BaseRequestHandler):
             "device": data,
         })
 
-    @catch_error_wraps(rdb.errors.ReqlNonExistenceError)
-    async def put(self, udid):
-        if not self.current_user.admin:
-            raise RuntimeError("Update requires admin")
-
-        props = self.get_payload()
-        await db.table("devices").get(udid).update({
-            "location": props['location'], "providerIP": props['providerIP'],
-        })
-        self.write_json({"success": True, "description": "updated"})
-
 
 class APIDevicePropertiesHandler(CorsMixin, BaseRequestHandler):
     @catch_error_wraps(rdb.errors.ReqlNonExistenceError)

--- a/web/views/device.py
+++ b/web/views/device.py
@@ -135,7 +135,7 @@ class APIDeviceHandler(CorsMixin, BaseRequestHandler):
 
         props = self.get_payload()
         await db.table("devices").get(udid).update({
-            "department": props['department'],
+            "location": props['location'], "providerIP": props['providerIP'],
         })
         self.write_json({"success": True, "description": "updated"})
 

--- a/web/views/provider.py
+++ b/web/views/provider.py
@@ -115,8 +115,11 @@ class ProviderHeartbeatWSHandler(BaseWebSocketHandler):
             updates['sources'] = {
                 self._id: source,
             }
+        whatsInputAddressIP = source['whatsInputAddress'].split(':')[0]
+        updates['locationProperties'] = dict(location=whatsInputAddressIP, providerIP=whatsInputAddressIP)
         updates['updatedAt'] = time_now()
         await db.table("devices").save(updates, udid)
+        await db.table("location").save(updates['locationProperties'], whatsInputAddressIP, excludeItems=['location'])  # yapf: disable
 
     async def on_message(self, message):
         req = json.loads(message)

--- a/web/views/user.py
+++ b/web/views/user.py
@@ -52,7 +52,6 @@ class APILocationListHandler(AdminRequestHandler):
         {
             "success": true,
             "location": [{
-                "id": "",
                 "location": "",
                 "providerIP" : ""
                 ...
@@ -65,11 +64,11 @@ class APILocationListHandler(AdminRequestHandler):
             "location": ret,
         })
 
-    async def put(self, locationID):
+    async def put(self, providerIP):
         """
         """
         payload = self.get_payload()
-        ret = await db.table("location").get(locationID).update(payload)  # yapf: disable
+        ret = await db.table("location") .get(providerIP).update(payload)  # yapf: disable
         self.write_json({
             "success": True,
             "location": ret,
@@ -84,10 +83,10 @@ class APILocationListHandler(AdminRequestHandler):
             "data": ret,
         })
 
-    async def delete(self, locationID):
+    async def delete(self, providerIP):
         """
         """
-        ret = await db.table("location").get(locationID).delete()  # yapf: disable
+        ret = await db.table("location").get(providerIP).delete()  # yapf: disable
         self.write_json({
             "success": True,
             "location": ret,

--- a/web/views/user.py
+++ b/web/views/user.py
@@ -45,6 +45,53 @@ class APIAdminListHandler(AdminRequestHandler):
             "data": ret,
         })
 
+class APILocationListHandler(AdminRequestHandler):
+    async def get(self):
+        """
+        Response example:
+        {
+            "success": true,
+            "location": [{
+                "id": "",
+                "location": "",
+                "providerIP" : ""
+                ...
+            }]
+        }
+        """
+        ret = await db.table("location").all()
+        self.write_json({
+            "success": True,
+            "location": ret,
+        })
+
+    async def put(self, locationID):
+        """
+        """
+        payload = self.get_payload()
+        ret = await db.table("location").get(locationID).update(payload)  # yapf: disable
+        self.write_json({
+            "success": True,
+            "location": ret,
+        })
+
+    async def post(self):
+        payload = self.get_payload()
+        ret = await db.table("location").save(payload)  # yapf: disable
+        # ret = await db.table("location").get(payload["location"]).update({"admin": True}) # yapf: disable
+        self.write_json({
+            "success": True,
+            "data": ret,
+        })
+
+    async def delete(self, locationID):
+        """
+        """
+        ret = await db.table("location").get(locationID).delete()  # yapf: disable
+        self.write_json({
+            "success": True,
+            "location": ret,
+        })
 
 class APIUserHandler(AuthRequestHandler):
     async def get(self):


### PR DESCRIPTION
需求：
由于公司设置到多部门，且会有多个provider，需要知道资产在哪里（不光是IP），且希望自动返显出来(最好是中文名)


本次修改内容：
1. 后台管理中，添加tab选项进行切换，管理员管理   和  设备-所在地管理
  设备-所在地管理  支持增删改查，主要是为了ip能对应个名字出来
  数据库添加了1张表 location

2. 首页调整所属部门列， 支持返显设备-所在地的中文名 或者  ip

3. database的save方法，新增了个过滤用的入参

备注：
返回的device中，新增了locationProperties， 本来想放在source里面的，但是看作者是做隐藏的，故没有去动