### PR TITLE
feat: iOS设备打开后自动设定帧率为30fps

### DIFF
--- a/templates/remotecontrol_apple.html
+++ b/templates/remotecontrol_apple.html
@@ -540,6 +540,13 @@
                 this.display.width = ret.value.width;
                 this.display.height = ret.value.height;
               }
+
+              // 设定帧率为30
+              $.ajax({
+                method: "post",
+                url: this.path2url("/session/" + this.session.id + "/appium/settings"),
+                data: '{"settings": {"mjpegServerFramerate": 30}}',
+              })
             })
           },
           stopUsing() {


### PR DESCRIPTION
默认 appium 的 wda 帧率为10，体验上感觉很卡。但实际上可以手动设定帧率的。

所以在连上设备后，增加一个设定帧率为30fps的请求，提升默认体验。